### PR TITLE
Fix "perdorogwaith" region

### DIFF
--- a/craftedMods.lotr.mpc.data.provider/src/craftedMods/lotr/mpc/data/provider/MusicPackDataImpl.java
+++ b/craftedMods.lotr.mpc.data.provider/src/craftedMods/lotr/mpc/data/provider/MusicPackDataImpl.java
@@ -70,7 +70,7 @@ public class MusicPackDataImpl implements MusicPackData
         this.regions.put ("farHarad",
             Arrays.asList ("savannah", "mountains", "swamp", "bushland", "mangrove", "volcano", "kanuka"));
         this.regions.put ("farHaradJungle", Arrays.asList ("jungle", "edge", "cloudForest"));
-        this.regions.put ("pertorogwaith", Arrays.asList ("pertorogwaith"));
+        this.regions.put ("perdorogwaith", Arrays.asList ("pertorogwaith"));
         this.regions.put ("utumno", Arrays.asList ("utumno"));
 
         this.regions = Collections.unmodifiableMap (this.regions);


### PR DESCRIPTION
In the Mod's readme.txt, the half troll region is specified as `perdorogwaith: {pertorogwaith}`, and upon loading a music pack created with the MPC the mod warns that `"LOTRMusic: No region named pertorogwaith!`